### PR TITLE
Marrked post "Github auth token on TravisCI" obsolete

### DIFF
--- a/source/_posts/2015-09-22-github-auth-token-on-travis.markdown
+++ b/source/_posts/2015-09-22-github-auth-token-on-travis.markdown
@@ -8,8 +8,8 @@ categories:
 - Github
 - Composer
 - TravisCI
-- TravisCI Series
 tags:
+- Obsolete
 - PHP
 - Github
 - Cache
@@ -24,6 +24,10 @@ The [composer cache](/2015/07/composer-cache-on-travis/) greatly speeds up your 
 ![Composer Github auth error](/images/posts/composer-github-auth-error.png)
 
 <!-- More -->
+
+# Obsolete post #
+
+[Github recently made a change to their API removing the need to do this.](https://github.com/composer/composer/issues/4884#issuecomment-195229989)
 
 ##### The setup #####
 


### PR DESCRIPTION
Since this morning there is no need anymore to set the github auth token for composer install during, updated the post accordingly after this comment: https://github.com/composer/composer/issues/4884#issuecomment-195229989